### PR TITLE
Support global options configuration

### DIFF
--- a/bin/incr
+++ b/bin/incr
@@ -10,6 +10,9 @@ include GLI::App
 program_desc('Tasteful utility to increment the version number and create a corresponding git tag.')
 version(Incr::VERSION)
 
+flag [:t,:tagNamePattern], :default_value => 'v%s'
+flag [:d,:versionFileDirectory], :default_value => '.', :desc => 'Directory where to search for version file.'
+
 pre do |global, command, options, args|
   if args.length != 1 || !['major', 'minor', 'patch'].any? {|segment| args.include?(segment)}
     STDERR.puts('Expecting a single argument: major, minor or patch.')
@@ -22,7 +25,7 @@ end
 desc('Increment the version of your NPM package.')
 command :npm do |cmd|
   cmd.action do |global_options, options, args|
-    npm = Incr::Command::Npm.new(args)
+    npm = Incr::Command::Npm.new(args, global_options)
     npm.execute
   end
 end

--- a/lib/incr/command/mix.rb
+++ b/lib/incr/command/mix.rb
@@ -1,14 +1,14 @@
 module Incr
   module Command
     class Mix
-      MIXFILE_FILENAME = 'mix.exs'.freeze
-
-      def initialize(args)
+      def initialize(args, global_options)
         @segment = args[0]
+        @mixFileFilename = File.join(".", global_options[:versionFileDirectory], 'mix.exs')
+        @tagPattern = global_options[:tagNamePattern]
       end
 
       def execute
-        file_content = parse_content(MIXFILE_FILENAME)
+        file_content = parse_content(@mixFileFilename)
         if file_content == nil
           return
         end
@@ -16,14 +16,16 @@ module Incr
         file_version = file_content.match(/version:\W*\"(\d*.\d*.\d*)",/)[1]
         old_version = SemVersion.new(file_version)
         new_version = Incr::Service::Version.increment_segment(old_version, @segment)
-        Incr::Service::FileHelper.replace_once(MIXFILE_FILENAME, version_pattern(old_version.to_s), version_pattern(new_version.to_s))
+        Incr::Service::FileHelper.replace_once(@mixFileFilename, version_pattern(old_version.to_s), version_pattern(new_version.to_s))
 
-        puts "v#{new_version.to_s}"
+        newTag = @tagPattern % new_version.to_s
+
+        puts newTag
 
         repository = Incr::Service::Repository.new('.')
-        repository.add(MIXFILE_FILENAME)
-        repository.commit(new_version.to_s)
-        repository.tag("v#{new_version.to_s}")
+        repository.add(@mixFileFilename)
+        repository.commit(newTag)
+        repository.tag(newTag)
       end
 
       private


### PR DESCRIPTION
Added new global options:
```
GLOBAL OPTIONS
    -d, --versionFileDirectory=arg - Directory where to search for version file. (default: .)
    -t, --tagNamePattern=arg       - (default: v%s)
```

Example:
`incr -d ./subprojects/web/ -t 'MyCustomTagPrefix/%s' npm patch`

This will:
- search for `package.json` and `package-lock.json` file inside `subprojects/web/`
- the tage name will be something like `MyCustomTagPrefix/2.3.4`
- the commit message will be `MyCustomTagPrefix/2.3.4`